### PR TITLE
remove description of size from depotlist

### DIFF
--- a/auvert/templates/exports/snippets/snippet_depotlist_header.html
+++ b/auvert/templates/exports/snippets/snippet_depotlist_header.html
@@ -1,0 +1,49 @@
+{% load juntagrico.depot_extras %}
+{% load i18n %}
+{% load juntagrico.config %}
+<table cellpadding="2" cellspacing="0" repeat="5">
+    <tr>
+        <th colspan="3" class="horz-left">{% comment "#TODO: get number of columns from data. workaround: there will be at least 3 columns" %}{% endcomment %}
+            <h2 class="depot">{{ depot.get_weekday_display }} - {{ depot.name }}</h2>
+            <h3 class="depotaddr">{{ depot.location.address }} ({% trans "Kontakt" %}: {{ depot.contact.first_name }} {{ depot.contact.last_name }})</h3>
+            <span class="pickup-details">{% trans "Abholung" %}: {{ depot.pickup_display }}</span>
+        </th>
+    </tr>
+    <tr>
+        <th class="namecol"></th>
+        {% for product in products %}
+            <th colspan="{{ product.sizes_for_depot_list|count }}" class="top-border {% if forloop.first %}left-border{% endif %}">{{ product.name }}
+            </th>
+        {% endfor %}
+        <th colspan="2" class="top-border right-border"></th>
+    </tr>
+    <tr class="bottom-border">
+        <td></td>
+        {% for product in products %}
+            {% for size in product.sizes_for_depot_list %}
+                <td class="small bottom-border {% if forloop.first %}left-border{% endif %}">{{ size.name }}</td>
+            {% empty %}
+                <td class="small bottom-border left-border"></td>
+            {% endfor %}
+        {% endfor %}
+        <td colspan="2" class="small bottom-border right-border"></td>
+    </tr>
+    <tr class="horz-center">
+        <td class="horz-left">{% trans "TOTAL" %}:</td>
+        {% for product in products %}
+            {% for size in product.sizes_for_depot_list %}
+                <td>{{ subscriptions|by_depot:depot|parts_by_size:size|active_on:date|count }}</td>
+            {% empty %}
+                <td></td>
+            {% endfor %}
+        {% endfor %}
+        <td colspan="2" ></td>
+    </tr>
+    <tr class="bottom-border horz-center">
+        <th class="namecol vert-bottom horz-left">{% trans "Name" %}</th>
+        {% for product in products %}
+            <th colspan="{{ product.sizes_for_depot_list|count }}"></th>
+        {% endfor %}
+        <th class="fontsmall vert-bottom">{% trans "abgeholt" %}</th>
+        <th class="fontsmall vert-bottom">{% vocabulary "package" %} {% trans "retour" %}</th>
+    </tr>


### PR DESCRIPTION
Temporary fix.
In Juntagrico 2.0 the description shown in the order process and the one in the depot list can be adjusted separately.